### PR TITLE
Better define main CRUD ops' return types

### DIFF
--- a/ts/backend/index.tests.ts
+++ b/ts/backend/index.tests.ts
@@ -35,7 +35,10 @@ export class FakeStorageBackend extends StorageBackend {
 
         const id = this.config.idGenerator(collection, object, options)
         this.createOperations.push({ object, id })
-        return { object: { ...object, [pkIndex]: id } }
+        return {
+            pk: id,
+            object: options.incObject ? { ...object, [pkIndex]: id } : undefined,
+        }
     }
 
     async findObjects() {
@@ -43,11 +46,11 @@ export class FakeStorageBackend extends StorageBackend {
     }
 
     async updateObjects() {
-
+        return { count: 1 }
     }
 
     async deleteObjects() {
-
+        return { count: 1 }
     }
 }
 

--- a/ts/types/manager.ts
+++ b/ts/types/manager.ts
@@ -17,7 +17,7 @@ import {
 } from './backend'
 
 export interface StorageCollection {
-    createObject(object, options?: CreateSingleOptions): Promise<CreateSingleResult>
+    createObject<PK=string, T=any>(object: T, options?: CreateSingleOptions): Promise<CreateSingleResult<PK, T>>
     findOneObject<T>(query, options?: FindSingleOptions): Promise<T | null>
     findObject<T>(query, options?: FindSingleOptions): Promise<T | null>
     findObjects<T>(query, options?: FindManyOptions): Promise<Array<T>>


### PR DESCRIPTION
Based on what we discussed this a while back on slack:
https://worldbrain.slack.com/archives/CBLN20LCU/p1545279785004100

I think it's probably better to decide on these return types early on. Not sure exactly about the choices; what do you think?