### PR TITLE
Add support for compound PK batch ops in test suite

### DIFF
--- a/ts/index.tests.ts
+++ b/ts/index.tests.ts
@@ -1,6 +1,6 @@
 import * as expect from 'expect'
 import StorageManager from '.'
-import { StorageBackend, FieldType, CollectionFields, Relationship, PrimitiveFieldType } from './types'
+import { StorageBackend, FieldType, CollectionFields, Relationship, PrimitiveFieldType, CollectionDefinitionMap } from './types'
 import { StorageBackendFeatureSupport } from './types/backend-features';
 import { FieldTypeRegistry } from './fields';
 import { Field } from './fields/types';
@@ -276,7 +276,7 @@ export function testStorageBackendOperations(backendCreator : StorexBackendTestB
         const relationshipType = options.relationshipType || 'childOf'
 
         const storageManager = new StorageManager({ backend: options.backend })
-        storageManager.registry.registerCollections({
+        const collectionDefinitions: CollectionDefinitionMap = {
             user: {
                 version: new Date(2019, 1, 1),
                 fields: options.userFields || {
@@ -292,7 +292,24 @@ export function testStorageBackendOperations(backendCreator : StorexBackendTestB
                     { [relationshipType as any]: 'user', ...relationshipOptions } as any
                 ]
             }
-        })
+        }
+
+        if (options.backend.supports('compoundPrimaryKeys')) {
+            collectionDefinitions.tag = {
+                version: new Date(2019, 1, 1),
+                fields: {
+                    name: { type: 'string' },
+                },
+                relationships: [
+                    { childOf: 'email', reverseAlias: 'tags', alias: 'email' },
+                ],
+                indices: [
+                    { field: ['name', 'email'], pk: true },
+                ],
+            }
+        }
+
+        storageManager.registry.registerCollections(collectionDefinitions)
         await storageManager.finishInitialization()
         await storageManager.backend.migrate()
         return { storageManager }
@@ -621,7 +638,27 @@ export function testStorageBackendOperations(backendCreator : StorexBackendTestB
             await storageManager.operation('executeBatch', [])
         })
 
-        it('should support batch operations with compound primary keys')
+        it('should support batch operations with compound primary keys', { shouldSupport: ['compoundPrimaryKeys'] }, async function (context) {
+            const { storageManager } = await setupChildOfTest({ backend: context.backend })
+            expect(storageManager.registry.collections['tag'].pkIndex)
+                .toEqual(expect.arrayContaining(['name', 'email']))
+
+            const { object: user1 } = await storageManager.collection('user').createObject({displayName: 'Jack'})
+            const { object: email1 } = await storageManager.collection('email').createObject({ user: user1.id, address: 'jack@jack.com' })
+
+            await storageManager.operation('executeBatch', [
+                { operation: 'createObject', collection: 'tag', args: { email: email1.id, name: 'cool' } },
+                { operation: 'createObject', collection: 'tag', args: { email: email1.id, name: 'groovy' } },
+                { operation: 'createObject', collection: 'tag', args: { email: email1.id, name: 'rad' } },
+            ])
+
+            expect(await storageManager.collection('tag').findObjects({ email: email1.id }))
+                .toEqual(expect.arrayContaining([
+                    { email: email1.id, name: 'cool' },
+                    { email: email1.id, name: 'groovy' },
+                    { email: email1.id, name: 'rad' },
+                ]))
+        })
 
         it('should support batches with updateObjects operations', { shouldSupport: ['executeBatch'] }, async function (context : TestContext) {
             const { storageManager } = await setupChildOfTest({ backend: context.backend })

--- a/ts/types/backend-features.ts
+++ b/ts/types/backend-features.ts
@@ -7,6 +7,7 @@ export interface StorageBackendFeatureSupport {
   updateWithRelationships? : boolean
   relationshipFetching? : boolean
   crossRelationshipQueries? : boolean
+  compoundPrimaryKeys?: boolean
   executeBatch? : boolean
   batchCreates? : boolean
   resultLimiting? : boolean


### PR DESCRIPTION
I'm not entirely sure if I'm going about this the correct way. 
I saw the empty `should support batch operations with compound primary keys` test and thought maybe that's what I should expand on (and which I did). 
Then I realized we'd need some new backend feature support flag for compound keys, so I added in `compoundPrimaryKeys`. 

Though I noticed running the test suite from the root storex workspace directory, the `should support batch operations with compound primary keys` test runs for the firestore backend (which I haven't touched), so maybe I'm wrong about the need for a new feature support flag.

How far am I off the correct path here @ShishKabab ?