### PR TITLE
Add syntax highlighting to code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Basic usage
 
 First, configure a StorageBackend and set up the StorageManager, which will be the main point of access to define, query and manipulate your data. For more in-depth information on how to do all of this, please refer to [the docs](./docs/0-start-here.md).
 
-```
+```typescript
 import StorageManager from 'storex'
 import { DexieStorageBackend } from 'storex-backend-dexie'
 

--- a/docs/0-start-here.md
+++ b/docs/0-start-here.md
@@ -71,7 +71,7 @@ In-depth documentation
 ======================
 
 * [Defining collections](./collections.md): This is about the steps above where you interact with storageManager.registry, describing the various options for your collections, fields and relationships.
-* [Interacting with data](./operations): How to query and manipulate your data.
+* [Interacting with data](./operations.md): How to query and manipulate your data.
 * [Introspecting collections](./registry.md): How you can use the available meta-data about your data in your applications and when writing a back-end.
 * [Using and writing middleware](./middleware.md): You can transform operations that your application does before they arrived at the `StorageBackend`.
 * [Using and writing backend plugins](./plugins.md): Backend-specific operations are implemented using plugins. Read how to use and write them here.

--- a/docs/0-start-here.md
+++ b/docs/0-start-here.md
@@ -21,14 +21,14 @@ How it works
 
 You initialize a StorageBackend imported from its respective package:
 
-```
+```typescript
 import { DexieStorageBackend } from '@worldbrain/storex-backend-dexie'
 const storageBackend = new DexieStorageBackend({dbName: 'my-awesome-product'})
 ```
 
 You construct the storage manager, which will give you access to the StorageRegistry and the collection objects to access your data:
 
-```
+```typescript
 const storageManager = new StorageManager({ backend: storageBackend })
 
 # More info about this below
@@ -49,7 +49,7 @@ const users = await storageManager.collection('user').findObjects({ name: 'Bob',
 ```
 
 Under the hood, the collection methods are convenience methods that call the central `storageManager.operation(...)` method:
-```
+```typescript
 await storageManager.operation('createObject', 'user', { name: 'bla' })
 await storageManager.operation('executeBatch', [
     { operation: 'createObject', collection: 'user', args: { name: 'Diane' } },

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,6 +1,6 @@
 Collections are defined by calls to the StorageRegistry.registerCollection(s) function:
 
-```
+```typescript
 storageManager.registry.registerCollections({
     user: {
         version: new Date(2018, 11, 11),
@@ -52,7 +52,7 @@ You can define three kinds of relationships between collections. `singleChildOf`
 ### singleChildOf
 
 Creates a one-to-one relationship:
-```
+```typescript
 storageManager.registry.registerCollections({
     email: {
         version: new Date(2018, 11, 11),
@@ -89,7 +89,7 @@ const key = await storageManager.collection('activationCode').findOneObject({ema
 ### childOf
 
 Creates a one-to-many relationship:
-```
+```typescript
 storageManager.registry.registerCollections({
     user: {
         version: new Date(2018, 11, 11),
@@ -129,7 +129,7 @@ const emails = await storageManager.collection('activationCode').findObjects({us
 ### connects
 
 Creates a many-to-many relationship by explictly defining a connection between them:
-```
+```typescript
 storageManager.registry.registerCollections({
     user: {
         version: new Date(2018, 11, 11),

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -1,6 +1,6 @@
 All CRUD operations under the hood use `StorageManager.operation()`, which then runs the operations through all configured middleware before calling `StorageBackend.operation()`. This is used by the device-to-device Sync functionality for example to log all database modifications to a separate log. `StorageMiddleware` usage looks like this:
 
-```
+```typescript
 import { StorageMiddleware } from '@worldbrain/storex/lib/types/middleware'
 
 export class LogMiddleware implements StorageMiddleware {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,7 +11,7 @@ Creates a new object and any necessary child objects, cleaning and preparing nec
 
 **Example**:
 
-```
+```typescript
 storageManager.registry.registerCollections({
     email: {
         version: new Date(2018, 11, 11),
@@ -35,7 +35,7 @@ Updates all objects matching `<filter>`, which a MongoDB-like filter.
 
 **Example**:
 
-```
+```typescript
 storageManager.registry.registerCollections({
     email: {
         version: new Date(2018, 11, 11),
@@ -61,7 +61,7 @@ Deletes all objects from the database matching `<filter>`, which a MongoDB-like 
 
 **Example**:
 
-```
+```typescript
 storageManager.registry.registerCollections({
     email: {
         version: new Date(2018, 11, 11),
@@ -88,7 +88,7 @@ Fetches all objects from a collection matching `filter`. Currently supported `op
 
 Example:
 
-```
+```typescript
 storageManager.registry.registerCollections({
     email: {
         version: new Date(2018, 11, 11),
@@ -115,7 +115,7 @@ Fetches a single objects from a collection matching `filter`. Currently supporte
 
 Example:
 
-```
+```typescript
 storageManager.registry.registerCollections({
     email: {
         version: new Date(2018, 11, 11),

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,6 +1,6 @@
 Storex allows you to implement custom operations on the back-end for application-specific functionality that you need to do on a lower level (directly execute an SQL statement for example), or include functionality you don't always want to include in your application (altering your schema structure for data migrations as an example.)
 
-```
+```typescript
 import StorageManager from "@worldbrain/storex";
 import { StorageBackendPlugin } from "@worldbrain/storex/lib/backend";
 import { SequelizeStorageBackend } from "@worldbrain/storex-backend-sequelize";


### PR DESCRIPTION
If you use a trip backtick followed by the code type, GitHub will format the output...